### PR TITLE
Release 0.4.0 add support for puppetlabs/apt >=2.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: "4.6.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "1.8.0"
+      ref: "2.1.0"
 
   symlinks:
     confluent_kafka: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
@@ -21,21 +17,5 @@ env:
   - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
 matrix:
   exclude:
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  # Ruby 2.1.0
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.4.0"
-  # Exclude older ruby for 4.0
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
   - PUPPET_VERSION="~> 3.7.5" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
 matrix:
   exclude:
   # Ruby 1.9.3
@@ -38,4 +38,4 @@ matrix:
     env: PUPPET_VERSION="~> 3.4.0"
   # Exclude older ruby for 4.0
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 2015-07-23 Release 0.4.0
 - Add support for puppetlabs/apt >=2.0.0
+- Remove support for ruby 1.8.7 and puppet 2.7
+- Cleanup travis matrix
 
 2015-04-28 Release 0.3.0
 - Ensure log env variables are exported so they are picked up by startup

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2015-07-23 Release 0.4.0
+- Add support for puppetlabs/apt >=2.0.0
+
 2015-04-28 Release 0.3.0
 - Ensure log env variables are exported so they are picked up by startup
 scripts

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,9 +13,14 @@ class confluent_kafka::install {
           architecture      => 'all',
           repos             => '',
           required_packages => 'debian-keyring debian-archive-keyring',
-          key               => '1A77041E0314E6C5A486524E670540C841468433',
-          key_source        => 'http://packages.confluent.io/deb/1.0/archive.key',
-          include_src       => false,
+          key               => {
+            'id'            => '1A77041E0314E6C5A486524E670540C841468433',
+            'source'        => 'http://packages.confluent.io/deb/1.0/archive.key',
+          },
+          include           => {
+            'deb'           => true,
+            'src'           => false,
+          },
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "chartbeat-confluent_kafka",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Chartbeat",
   "summary": "Installs Confluent's Kafka Package",
   "license": "MIT",
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": "1.8.0"
+      "version_requirement": ">= 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This removes support for puppetlabs/apt <=2.0.0. Onward and upward.