### PR TITLE
add missing shebang to init script

### DIFF
--- a/files/kafka.init
+++ b/files/kafka.init
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 NAME=kafka
 CONFIG_PATH=/etc/kafka
 DEFAULT=/etc/default/$NAME


### PR DESCRIPTION
On a systemd system (debian jessie), without a shebang, systemd fails
to start kafka with exit status 203, e.g:

byf0.kafka0.te1508 /etc/kafka # /etc/init.d/kafka start
Starting kafka (via systemctl): kafka.serviceJob for kafka.service
failed. See 'systemctl status kafka.service' and 'journalctl -xn' for
details.
 failed!
kafka0 /etc/kafka # systemctl status kafka.service
● kafka.service - (null)
   Loaded: loaded (/etc/init.d/kafka)
   Active: failed (Result: exit-code) since Fri 2015-12-11 14:12:09 UTC;
10s ago
  Process: 14699 ExecStart=/etc/init.d/kafka start (code=exited,
status=203/EXEC)

Dec 11 14:12:09 kafka0.example.net systemd[1]: kafka.service:
control process exited, code=exited status=203
Dec 11 14:12:09 kafka0.example.net systemd[1]: Failed to start
(null).
Dec 11 14:12:09 kafka0.example.net systemd[1]: Unit
kafka.service entered failed state.

journalctl -xn gives no useful debug information, either.