### PR TITLE
Add support for newer Confluent Platform versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2024-01-23 Release 0.5.3
+- Add support for installing platform version 6+
+- Make apt key ID configurable
+
 2016-11-08 Release 0.5.2
 - Fix bug in apt-get update, dont run on every puppet run
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,39 +63,38 @@
 #
 
 class confluent_kafka (
-  $package_name      = $::confluent_kafka::params::package_name,
-  $service_name      = $::confluent_kafka::params::service_name,
-  $brokers           = $::confluent_kafka::params::brokers,
-  $scala_version     = $::confluent_kafka::params::scala_version,
-  $version           = $::confluent_kafka::params::version,
-  $install_java      = $::confluent_kafka::params::install_java,
-  $install_service   = $::confluent_kafka::params::install_service,
-  $restart_on_change = $::confluent_kafka::params::restart_on_change,
-  $manage_service    = $::confluent_kafka::params::manage_service,
-  $manage_repo       = $::confluent_kafka::params::manage_repo,
-  $kafka_config      = $::confluent_kafka::params::kafka_config_defaults,
-  $zk_hosts          = $::confluent_kafka::params::zk_hosts,
-  $zk_chroot         = $::confluent_kafka::params::zk_chroot,
-  $log_dirs          = $::confluent_kafka::params::log_dirs,
-  $app_log_dir       = $::confluent_kafka::params::app_log_dir,
-  $jvm_heap_mem      = $::confluent_kafka::params::jvm_heap_mem,
-  $jvm_perf_opts     = $::confluent_kafka::params::jvm_perf_opts,
-  $jmx_opts          = $::confluent_kafka::params::jmx_opts,
-  $log4j_opts        = $::confluent_kafka::params::log4j_opts,
-  $platform_version  = $::confluent_kafka::params::platform_version,
-
-) inherits ::confluent_kafka::params {
-
+  $package_name      = $confluent_kafka::params::package_name,
+  $service_name      = $confluent_kafka::params::service_name,
+  $brokers           = $confluent_kafka::params::brokers,
+  $scala_version     = $confluent_kafka::params::scala_version,
+  $version           = $confluent_kafka::params::version,
+  $install_java      = $confluent_kafka::params::install_java,
+  $install_service   = $confluent_kafka::params::install_service,
+  $restart_on_change = $confluent_kafka::params::restart_on_change,
+  $manage_service    = $confluent_kafka::params::manage_service,
+  $manage_repo       = $confluent_kafka::params::manage_repo,
+  $kafka_config      = $confluent_kafka::params::kafka_config_defaults,
+  $zk_hosts          = $confluent_kafka::params::zk_hosts,
+  $zk_chroot         = $confluent_kafka::params::zk_chroot,
+  $log_dirs          = $confluent_kafka::params::log_dirs,
+  $app_log_dir       = $confluent_kafka::params::app_log_dir,
+  $jvm_heap_mem      = $confluent_kafka::params::jvm_heap_mem,
+  $jvm_perf_opts     = $confluent_kafka::params::jvm_perf_opts,
+  $jmx_opts          = $confluent_kafka::params::jmx_opts,
+  $log4j_opts        = $confluent_kafka::params::log4j_opts,
+  $platform_version  = $confluent_kafka::params::platform_version,
+  $apt_key_id = $confluent_kafka::params::apt_key_id,
+) inherits confluent_kafka::params {
   # Verification
   validate_array($log_dirs)
   validate_array($zk_hosts)
   validate_hash($brokers)
   validate_hash($kafka_config)
 
-  $zk_string = join( [join($::confluent_kafka::zk_hosts, ','), $::confluent_kafka::zk_chroot] )
+  $zk_string = join([join($confluent_kafka::zk_hosts, ','), $confluent_kafka::zk_chroot])
 
-  class { '::confluent_kafka::install': } ->
-  class { '::confluent_kafka::config': } ->
-  class { '::confluent_kafka::service': } ->
-  Class['::confluent_kafka']
+  class { 'confluent_kafka::install': }
+  -> class { 'confluent_kafka::config': }
+  -> class { 'confluent_kafka::service': }
+  -> Class['confluent_kafka']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,9 @@
 #
 # === Parameters
 #
+# [*apt_key_id*]
+#   The GPG key ID for the apt repository. Only used if manage_repo is true.
+#
 # [*package_name*]
 #   Base name of the package, we append *scala_version*  to get full name
 #
@@ -63,27 +66,27 @@
 #
 
 class confluent_kafka (
-  $package_name      = $confluent_kafka::params::package_name,
-  $service_name      = $confluent_kafka::params::service_name,
+  $app_log_dir       = $confluent_kafka::params::app_log_dir,
+  $apt_key_id        = $confluent_kafka::params::apt_key_id,
   $brokers           = $confluent_kafka::params::brokers,
-  $scala_version     = $confluent_kafka::params::scala_version,
-  $version           = $confluent_kafka::params::version,
   $install_java      = $confluent_kafka::params::install_java,
   $install_service   = $confluent_kafka::params::install_service,
-  $restart_on_change = $confluent_kafka::params::restart_on_change,
-  $manage_service    = $confluent_kafka::params::manage_service,
-  $manage_repo       = $confluent_kafka::params::manage_repo,
-  $kafka_config      = $confluent_kafka::params::kafka_config_defaults,
-  $zk_hosts          = $confluent_kafka::params::zk_hosts,
-  $zk_chroot         = $confluent_kafka::params::zk_chroot,
-  $log_dirs          = $confluent_kafka::params::log_dirs,
-  $app_log_dir       = $confluent_kafka::params::app_log_dir,
+  $jmx_opts          = $confluent_kafka::params::jmx_opts,
   $jvm_heap_mem      = $confluent_kafka::params::jvm_heap_mem,
   $jvm_perf_opts     = $confluent_kafka::params::jvm_perf_opts,
-  $jmx_opts          = $confluent_kafka::params::jmx_opts,
+  $kafka_config      = $confluent_kafka::params::kafka_config_defaults,
+  $log_dirs          = $confluent_kafka::params::log_dirs,
   $log4j_opts        = $confluent_kafka::params::log4j_opts,
+  $manage_repo       = $confluent_kafka::params::manage_repo,
+  $manage_service    = $confluent_kafka::params::manage_service,
+  $package_name      = $confluent_kafka::params::package_name,
   $platform_version  = $confluent_kafka::params::platform_version,
-  $apt_key_id        = $confluent_kafka::params::apt_key_id,
+  $restart_on_change = $confluent_kafka::params::restart_on_change,
+  $scala_version     = $confluent_kafka::params::scala_version,
+  $service_name      = $confluent_kafka::params::service_name,
+  $version           = $confluent_kafka::params::version,
+  $zk_chroot         = $confluent_kafka::params::zk_chroot,
+  $zk_hosts          = $confluent_kafka::params::zk_hosts,
 ) inherits confluent_kafka::params {
   # Verification
   validate_array($log_dirs)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class confluent_kafka (
   $jmx_opts          = $confluent_kafka::params::jmx_opts,
   $log4j_opts        = $confluent_kafka::params::log4j_opts,
   $platform_version  = $confluent_kafka::params::platform_version,
-  $apt_key_id = $confluent_kafka::params::apt_key_id,
+  $apt_key_id        = $confluent_kafka::params::apt_key_id,
 ) inherits confluent_kafka::params {
   # Verification
   validate_array($log_dirs)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,7 @@ class confluent_kafka::install {
             Package['debian-archive-keyring'],
           ],
           key          => {
-            'name'   => "confluent-${confluent_kafka::platform_version}",
+            'id'     => $confluent_kafka::apt_key_id,
             'source' => "http://packages.confluent.io/deb/${confluent_kafka::platform_version}/archive.key",
           },
           include      => {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,57 +3,55 @@
 # This class is called from confluent_kafka for install.
 #
 
-
 class confluent_kafka::install {
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian': {
-      if $::confluent_kafka::manage_repo {
+      if $confluent_kafka::manage_repo {
         include apt
         ensure_packages(['debian-keyring', 'debian-archive-keyring'])
         apt::source { 'confluent':
-          location          => "http://packages.confluent.io/deb/${::confluent_kafka::platform_version}",
-          release           => 'stable',
-          architecture      => 'amd64',
-          repos             => 'main',
-          notify            => Exec[apt-update],
-          require           => [
+          location     => "http://packages.confluent.io/deb/${confluent_kafka::platform_version}",
+          release      => 'stable',
+          architecture => 'amd64',
+          repos        => 'main',
+          notify       => Exec['apt-update'],
+          require      => [
             Package['debian-keyring'],
             Package['debian-archive-keyring'],
           ],
-          key               => {
-            'id'            => '1A77041E0314E6C5A486524E670540C841468433',
-            'source'        => "http://packages.confluent.io/deb/${::confluent_kafka::platform_version}/archive.key",
+          key          => {
+            'id'     => '1A77041E0314E6C5A486524E670540C841468433',
+            'source' => "http://packages.confluent.io/deb/${confluent_kafka::platform_version}/archive.key",
           },
-          include           => {
-            'deb'           => true,
-            'src'           => false,
+          include      => {
+            'deb' => true,
+            'src' => false,
           },
         }
       }
     }
   }
 
-
   exec { 'apt-get update':
-    command     => "/usr/bin/apt-get update",
-    alias       => "apt-update",
+    command     => '/usr/bin/apt-get update',
+    alias       => 'apt-update',
     refreshonly => true,
   }
 
-  if $::confluent_kafka::install_java {
+  if $confluent_kafka::install_java {
     class { 'java':
       distribution => 'jdk',
     }
   }
 
-  $_pkg_name = versioncmp($confluent_kafka::platform_version, '6.0') ? {
-    -1 => ${confluent_kafka::package_name}-${::confluent_kafka::scala_version},
-    default => $confluent_kafka::package_name
+  case versioncmp($confluent_kafka::platform_version, '6.0') {
+    -1: { $_pkg_name = "${confluent_kafka::package_name}-${confluent_kafka::scala_version}" }
+    default: { $_pkg_name = $confluent_kafka::package_name }
   }
 
   package { $_pkg_name:
-    require => Exec[apt-update],
-    ensure => $::confluent_kafka::version,
+    ensure  => $confluent_kafka::version,
+    require => Exec['apt-update'],
   }
 
   group { 'kafka':
@@ -66,13 +64,12 @@ class confluent_kafka::install {
     require => Group['kafka'],
   }
 
-  if $::confluent_kafka::install_service {
-    file { "/etc/init.d/${::confluent_kafka::service_name}":
+  if $confluent_kafka::install_service {
+    file { "/etc/init.d/${confluent_kafka::service_name}":
       mode   => '0755',
       owner  => 'root',
       group  => 'root',
       source => 'puppet:///modules/confluent_kafka/kafka.init',
     }
   }
-
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,7 +46,12 @@ class confluent_kafka::install {
     }
   }
 
-  package { "${::confluent_kafka::package_name}-${::confluent_kafka::scala_version}":
+  $_pkg_name = versioncmp($confluent_kafka::platform_version, '6.0') ? {
+    -1 => ${confluent_kafka::package_name}-${::confluent_kafka::scala_version},
+    default => $confluent_kafka::package_name
+  }
+
+  package { $_pkg_name:
     require => Exec[apt-update],
     ensure => $::confluent_kafka::version,
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,7 @@ class confluent_kafka::install {
             Package['debian-archive-keyring'],
           ],
           key          => {
-            'id'     => '1A77041E0314E6C5A486524E670540C841468433',
+            'name'   => "confluent-${confluent_kafka::platform_version}",
             'source' => "http://packages.confluent.io/deb/${confluent_kafka::platform_version}/archive.key",
           },
           include      => {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class confluent_kafka::params {
   $scala_version     = '2.10.4'
   $platform_version  = '1.0'
   $service_name      = 'kafka'
-  $package_name      = "confluent-kafka"
+  $package_name      = 'confluent-kafka'
   $version           = '0.8.2.0-1'
   $install_java      = false
   $install_service   = true
@@ -23,9 +23,10 @@ class confluent_kafka::params {
   $jvm_perf_opts     = '-XX:PermSize=48m -XX:MaxPermSize=48m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35'
   $jmx_opts          = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote.port=9999'
   $log4j_opts        = '-Dlog4j.configuration=file:/etc/kafka/log4j.properties'
+  $apt_key_id = '1A77041E0314E6C5A486524E670540C841468433'
 
   $brokers           = {
-      'localhost' => 0,
+    'localhost' => 0,
   }
 
   $kafka_config_defaults = {
@@ -90,7 +91,6 @@ class confluent_kafka::params {
     'leader.imbalance.check.interval.seconds'       => '300',
     'offset.metadata.max.bytes'                     => '1024',
     'delete.topic.enable'                           => false,
-    'inter.broker.protocol.version'                 => '0.8.2.X'
+    'inter.broker.protocol.version'                 => '0.8.2.X',
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,26 +4,26 @@
 # It sets variables according to platform.
 #
 class confluent_kafka::params {
-  $scala_version     = '2.10.4'
-  $platform_version  = '1.0'
-  $service_name      = 'kafka'
-  $package_name      = 'confluent-kafka'
-  $version           = '0.8.2.0-1'
+  $app_log_dir       = '/var/log/kafka'
+  $apt_key_id = '1A77041E0314E6C5A486524E670540C841468433'
   $install_java      = false
   $install_service   = true
-  $restart_on_change = false
-  $manage_service    = true
-  $manage_repo       = true
-  $zk_hosts          = ['localhost:2181']
-  $zk_chroot         = ''
-  $max_nofiles       = '65535'
-  $log_dirs          = ['/tmp/kafka-logs']
-  $app_log_dir       = '/var/log/kafka'
+  $jmx_opts          = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote.port=9999'
   $jvm_heap_mem      = '-Xmx1G -Xms1G'
   $jvm_perf_opts     = '-XX:PermSize=48m -XX:MaxPermSize=48m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35'
-  $jmx_opts          = '-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.net.preferIPv4Stack=true -Dcom.sun.management.jmxremote.port=9999'
+  $log_dirs          = ['/tmp/kafka-logs']
   $log4j_opts        = '-Dlog4j.configuration=file:/etc/kafka/log4j.properties'
-  $apt_key_id = '1A77041E0314E6C5A486524E670540C841468433'
+  $manage_repo       = true
+  $manage_service    = true
+  $max_nofiles       = '65535'
+  $package_name      = 'confluent-kafka'
+  $platform_version  = '1.0'
+  $restart_on_change = false
+  $scala_version     = '2.10.4'
+  $service_name      = 'kafka'
+  $version           = '0.8.2.0-1'
+  $zk_chroot         = ''
+  $zk_hosts          = ['localhost:2181']
 
   $brokers           = {
     'localhost' => 0,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "chartbeat-confluent_kafka",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": "Chartbeat",
   "summary": "Installs Confluent's Kafka Package",
   "license": "MIT",


### PR DESCRIPTION
Confluent platform version 6+ has stopped embedding the scala version in the package name. This handles that package naming change. It also adds the ability to change the apt key id, as that has changed for newer versions also.

Additionally made some minor syntax cleanups.